### PR TITLE
Player name highlighting & a fix

### DIFF
--- a/twitch_broker/overlay/twitch_broker_overlay.html
+++ b/twitch_broker/overlay/twitch_broker_overlay.html
@@ -27,6 +27,8 @@
 
     setInterval(function() {
         $.get('twitch_broker_overlay.json', function(data) {
+            if (typeof data === "string") data = JSON.parse(data);
+
             const dataString = JSON.stringify(data);
             if (dataString !== previousData) {
 

--- a/twitch_broker/twitchbroker/overlay_data.py
+++ b/twitch_broker/twitchbroker/overlay_data.py
@@ -5,6 +5,7 @@ import itertools
 from dataclasses import dataclass
 from typing import List
 
+from rlbot.utils.structures.game_data_struct import GameTickPacket, PlayerInfo
 from rlbot_action_client.models import BotAction
 from twitchbroker.action_and_server_id import AvailableActionsAndServerId, ActionAndServerId
 
@@ -65,3 +66,19 @@ def serialize_for_overlay(o):
     if hasattr(o, 'to_dict'):
         return o.to_dict()
     return o.__dict__
+
+
+def get_highlighted_player_name(player: PlayerInfo) -> str:
+    color = '#1E90FF' if player.team == 0 else '#FF8C00'
+    return f'<b style="color: {color}">{player.name}</b>'
+
+
+def highlight_player_names(overlay_data: OverlayData, packet: GameTickPacket):
+    players = [packet.game_cars[i] for i in range(packet.num_cars)]
+
+    for section in overlay_data.sections:
+        for action in section.actions:
+            for player in players:
+                if player.name in action.action.description:
+                    action.action.description = action.action.description.replace(
+                        player.name, get_highlighted_player_name(player))

--- a/twitch_broker/twitchbroker/twitch_broker.py
+++ b/twitch_broker/twitchbroker/twitch_broker.py
@@ -10,7 +10,7 @@ from rlbot.utils.game_state_util import GameState, GameInfoState
 from rlbot_action_client import Configuration, ActionApi, ApiClient, ActionChoice
 from twitchbroker.action_and_server_id import AvailableActionsAndServerId
 from twitchbroker.overlay_data import OverlayData, serialize_for_overlay, generate_menu_id, generate_menu, \
-    CommandAcknowledgement
+    CommandAcknowledgement, highlight_player_names
 from rlbot_twitch_broker_client.models.chat_line import ChatLine
 from rlbot_twitch_broker_server import chat_buffer
 from rlbot_twitch_broker_server import client_registry
@@ -95,6 +95,7 @@ class TwitchBroker(BaseScript):
             twitch_thread.start()
 
     def write_json_for_overlay(self, overlay_data: OverlayData):
+        highlight_player_names(overlay_data, self.game_tick_packet)
         json_string = json.dumps(overlay_data, default=serialize_for_overlay)
         self.json_file.write_text(json_string)
 


### PR DESCRIPTION
I had a problem where the overlay wouldn't display anything. I found out the reason was that in
```javascript
$.get('twitch_broker_overlay.json', function(data) {
```
the `data` variable was set to a string, instead of an object like it's supposed to. I really don't know why that happens to me, but in case it could happen to someone else I added a fix.


Also added player name highlighting to the overlay, to make it a little nicer to read. Color is based on the player's team.
![image](https://user-images.githubusercontent.com/18472149/83972754-40b68480-a8e2-11ea-8bf1-48e325bd3e0d.png)
It's handled by the twitch broker script, so the other scripts don't have to worry about it.